### PR TITLE
Update keychron.service

### DIFF
--- a/script/keychron.service
+++ b/script/keychron.service
@@ -3,8 +3,8 @@ Description=The command to make the Keychron K2-k4 work with Function keys
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c "sudo echo 1 | sudo tee /sys/module/hid_apple/parameters/fnmode"
-ExecStop=/bin/bash -c "sudo echo 0 | sudo tee /sys/module/hid_apple/parameters/fnmode"
+ExecStart=/bin/bash -c "sudo echo 2 | sudo tee /sys/module/hid_apple/parameters/fnmode"
+ExecStop=/bin/bash -c "sudo echo 1 | sudo tee /sys/module/hid_apple/parameters/fnmode"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
For the K3 using Ubuntu 20.0.4 LTS we need to set it to 2 for the fn keys to work, and 1 or 0 for them to deactivate.